### PR TITLE
Bug fix in uaz id filtering

### DIFF
--- a/NodesEdges.R
+++ b/NodesEdges.R
@@ -12,9 +12,9 @@ none_cont <- read.csv("NC_tanh.csv")
 prop_df <- rbind(activation, none_cont)
 
 prop_df <- prop_df %>%
-  filter(!grepl(':uaz:', ID_PAIRS))
+  filter(!grepl('uaz', ID_PAIRS))
 prop_df <- prop_df %>%
-  filter(!grepl(':UAZ:', ID_PAIRS))
+  filter(!grepl('UAZ', ID_PAIRS))
 
 ## ------------------------------------------------------------------------------------------------------
 controllers=prop_df %>%


### PR DESCRIPTION
`filter(!grepl(':uaz:', ID_PAIRS))` misses uaz ids that do not have the colons around them.
 Example ID_PAIR: "uniprot:P31944\|uaz:UAZ484644"
Removed the colons, so now it can grep for all ids containing "uaz".